### PR TITLE
replace bytes.Equal with subtle.ConstantTimeCompare

### DIFF
--- a/xmss.go
+++ b/xmss.go
@@ -21,7 +21,7 @@
 package xmss
 
 import (
-	"bytes"
+	"crypto/subtle"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -285,7 +285,7 @@ func Verify(bsig, msg, bpk []byte) bool {
 	binary.BigEndian.PutUint32(r[64+28:], sig.idx)
 	hmsg := hashMsg(r, msg)
 	root := rootFromSig(sig.idx, hmsg, sig.xmssSigBody, prf, 0, 0)
-	return bytes.Equal(root, pk.Root)
+	return subtle.ConstantTimeCompare(root, pk.Root) == 1
 }
 
 func rootFromSig(idx uint32, hmsg []byte, body *xmssSigBody, prf *prf, layer uint32, tree uint64) []byte {

--- a/xmss_mt.go
+++ b/xmss_mt.go
@@ -21,7 +21,7 @@
 package xmss
 
 import (
-	"bytes"
+	"crypto/subtle"
 	"crypto/hmac"
 	"encoding/binary"
 	"encoding/json"
@@ -252,7 +252,7 @@ func VerifyMT(bsig, msg, bpk []byte) bool {
 		idxTree = idxTree >> (pk.H / pk.D)
 		node = rootFromSig(idxLeaf, node, sig.sigs[j], prf, j, idxTree)
 	}
-	return bytes.Equal(pk.Root, node)
+	return subtle.ConstantTimeCompare(pk.Root, node) == 1
 }
 
 type privKeyMT struct {


### PR DESCRIPTION
## Proposal
replace `bytes.Equal` with `subtle.ConstantTimeCompare` for root node comparison on user facing Verify method. This is simply to ensure no timing attack leaks occur on the byte comparison by ensuring that all bytes are compared regardless of placement of a mismatch.

I ran `go test` with these changes and all test passed.